### PR TITLE
Nahrazení deprecated funkce get_woocommerce_term_meta().

### DIFF
--- a/ceske-sluzby.php
+++ b/ceske-sluzby.php
@@ -1111,16 +1111,16 @@ function ceske_sluzby_xml_kategorie_pridat_pole() {
 function ceske_sluzby_xml_kategorie_upravit_pole( $term ) {
   $checked = '';
   $global_data = ceske_sluzby_xml_ziskat_globalni_hodnoty();
-  $heureka_kategorie = get_woocommerce_term_meta( $term->term_id, 'ceske-sluzby-xml-heureka-kategorie', true );
-  $heureka_productname = get_woocommerce_term_meta( $term->term_id, 'ceske-sluzby-xml-heureka-productname', true );
-  $zbozi_kategorie = get_woocommerce_term_meta( $term->term_id, 'ceske-sluzby-xml-zbozi-kategorie', true );
-  $zbozi_productname = get_woocommerce_term_meta( $term->term_id, 'ceske-sluzby-xml-zbozi-productname', true );
-  $glami_kategorie = get_woocommerce_term_meta( $term->term_id, 'ceske-sluzby-xml-glami-kategorie', true );
-  $kategorie_extra_message_ulozeno = get_woocommerce_term_meta( $term->term_id, 'ceske-sluzby-xml-zbozi-extra-message', true );
-  $xml_vynechano_ulozeno = get_woocommerce_term_meta( $term->term_id, 'ceske-sluzby-xml-vynechano', true );
-  $xml_feed_vynechano_ulozeno = get_woocommerce_term_meta( $term->term_id, 'ceske-sluzby-xml-feed-vynechano', true );
-  $xml_erotika_ulozeno = get_woocommerce_term_meta( $term->term_id, 'ceske-sluzby-xml-erotika', true );
-  $xml_stav_produktu = get_woocommerce_term_meta( $term->term_id, 'ceske-sluzby-xml-stav-produktu', true );
+  $heureka_kategorie = get_term_meta( $term->term_id, 'ceske-sluzby-xml-heureka-kategorie', true );
+  $heureka_productname = get_term_meta( $term->term_id, 'ceske-sluzby-xml-heureka-productname', true );
+  $zbozi_kategorie = get_term_meta( $term->term_id, 'ceske-sluzby-xml-zbozi-kategorie', true );
+  $zbozi_productname = get_term_meta( $term->term_id, 'ceske-sluzby-xml-zbozi-productname', true );
+  $glami_kategorie = get_term_meta( $term->term_id, 'ceske-sluzby-xml-glami-kategorie', true );
+  $kategorie_extra_message_ulozeno = get_term_meta( $term->term_id, 'ceske-sluzby-xml-zbozi-extra-message', true );
+  $xml_vynechano_ulozeno = get_term_meta( $term->term_id, 'ceske-sluzby-xml-vynechano', true );
+  $xml_feed_vynechano_ulozeno = get_term_meta( $term->term_id, 'ceske-sluzby-xml-feed-vynechano', true );
+  $xml_erotika_ulozeno = get_term_meta( $term->term_id, 'ceske-sluzby-xml-erotika', true );
+  $xml_stav_produktu = get_term_meta( $term->term_id, 'ceske-sluzby-xml-stav-produktu', true );
   $xml_feed_heureka = get_option( 'wc_ceske_sluzby_xml_feed_heureka-aktivace' );
   $xml_feed_zbozi = get_option( 'wc_ceske_sluzby_xml_feed_zbozi-aktivace' );
   $xml_feed_glami = get_option( 'wc_ceske_sluzby_xml_feed_glami-aktivace' );
@@ -1303,7 +1303,7 @@ function ceske_sluzby_xml_kategorie_ulozit( $term_id, $tt_id = '', $taxonomy = '
           $value = str_replace( 'Glami.cz | ', '', $value );
           $value = str_replace( 'Glami.sk | ', '', $value );
         }
-        $ulozeno_text = get_woocommerce_term_meta( $term_id, $key, true );
+        $ulozeno_text = get_term_meta( $term_id, $key, true );
         if ( ! empty( $value ) ) {
           update_woocommerce_term_meta( $term_id, $key, esc_attr( $value ) );
         } elseif ( ! empty( $ulozeno_text ) ) {
@@ -1319,7 +1319,7 @@ function ceske_sluzby_xml_kategorie_ulozit( $term_id, $tt_id = '', $taxonomy = '
       'ceske-sluzby-xml-zbozi-extra-message'
     );
     foreach ( $ukladana_data_checkbox as $key ) {
-      $ulozeno_checkbox = get_woocommerce_term_meta( $term_id, $key, true );
+      $ulozeno_checkbox = get_term_meta( $term_id, $key, true );
       if ( isset( $_POST[ $key ] ) ) {
         $value = $_POST[ $key ];
         if ( ! empty( $value ) ) {
@@ -1340,13 +1340,13 @@ function ceske_sluzby_xml_kategorie_pridat_sloupec( $columns ) {
 
 function ceske_sluzby_xml_kategorie_sloupec( $columns, $column, $id ) {
   if ( 'xml-heureka' == $column ) {
-    $heureka_kategorie = get_woocommerce_term_meta( $id, 'ceske-sluzby-xml-heureka-kategorie', true );
+    $heureka_kategorie = get_term_meta( $id, 'ceske-sluzby-xml-heureka-kategorie', true );
     $heureka_nazev = false;
     if ( $heureka_kategorie ) {
       $columns .= 'Heureka: <a href="#" title="' . $heureka_kategorie . '">KA</a>';
       $heureka_nazev = true;
     }
-    $heureka_productname = get_woocommerce_term_meta( $id, 'ceske-sluzby-xml-heureka-productname', true );
+    $heureka_productname = get_term_meta( $id, 'ceske-sluzby-xml-heureka-productname', true );
     if ( $heureka_productname ) {
       if ( $heureka_nazev ) {
         $columns .= ' <a href="#" title="' . $heureka_productname . '">PR</a>';
@@ -1358,13 +1358,13 @@ function ceske_sluzby_xml_kategorie_sloupec( $columns, $column, $id ) {
     if ( $heureka_nazev ) {
       $columns .= '<br />';
     }
-    $zbozi_kategorie = get_woocommerce_term_meta( $id, 'ceske-sluzby-xml-zbozi-kategorie', true );
+    $zbozi_kategorie = get_term_meta( $id, 'ceske-sluzby-xml-zbozi-kategorie', true );
     $zbozi_nazev = false;
     if ( $zbozi_kategorie ) {
       $columns .= 'Zboží: <a href="#" title="' . $zbozi_kategorie . '">KA</a>';
       $zbozi_nazev = true;
     }
-    $zbozi_productname = get_woocommerce_term_meta( $id, 'ceske-sluzby-xml-zbozi-productname', true );
+    $zbozi_productname = get_term_meta( $id, 'ceske-sluzby-xml-zbozi-productname', true );
     if ( $zbozi_productname ) {
       if ( $zbozi_nazev ) {
         $columns .= ' <a href="#" title="' . $zbozi_productname . '">PR</a>';
@@ -1373,9 +1373,9 @@ function ceske_sluzby_xml_kategorie_sloupec( $columns, $column, $id ) {
         $zbozi_nazev = true;
       }
     }
-    $glami_kategorie = get_woocommerce_term_meta( $id, 'ceske-sluzby-xml-glami-kategorie', true );
+    $glami_kategorie = get_term_meta( $id, 'ceske-sluzby-xml-glami-kategorie', true );
     $extra_message_aktivace = get_option( 'wc_ceske_sluzby_xml_feed_zbozi_extra_message-aktivace' );
-    $kategorie_extra_message_ulozeno = get_woocommerce_term_meta( $id, 'ceske-sluzby-xml-zbozi-extra-message', true );
+    $kategorie_extra_message_ulozeno = get_term_meta( $id, 'ceske-sluzby-xml-zbozi-extra-message', true );
     if ( ! empty( $kategorie_extra_message_ulozeno ) ) {
       $extra_message_array = ceske_sluzby_ziskat_nastaveni_zbozi_extra_message();
       foreach ( $kategorie_extra_message_ulozeno as $key => $value ) {
@@ -1398,8 +1398,8 @@ function ceske_sluzby_xml_kategorie_sloupec( $columns, $column, $id ) {
       }
       $columns .= 'Glami: <a href="#" title="' . $glami_kategorie . '">KA</a>';
     }
-    $kategorie_vynechano = get_woocommerce_term_meta( $id, 'ceske-sluzby-xml-vynechano', true );
-    $kategorie_feed_vynechano = get_woocommerce_term_meta( $id, 'ceske-sluzby-xml-feed-vynechano', true );
+    $kategorie_vynechano = get_term_meta( $id, 'ceske-sluzby-xml-vynechano', true );
+    $kategorie_feed_vynechano = get_term_meta( $id, 'ceske-sluzby-xml-feed-vynechano', true );
     if ( $kategorie_vynechano ) {
       $columns .= '<span style="margin-left: 10px; color: red; font-weight: bold;">X</span>';
     } elseif ( $kategorie_feed_vynechano ) {
@@ -1417,7 +1417,7 @@ function ceske_sluzby_xml_kategorie_sloupec( $columns, $column, $id ) {
       $title .= '"';
       $columns .= '<span style="margin-left: 10px; color: red;"' . $title . '>x</span>';
     }
-    $stav_produktu = get_woocommerce_term_meta( $id, 'ceske-sluzby-xml-stav-produktu', true );
+    $stav_produktu = get_term_meta( $id, 'ceske-sluzby-xml-stav-produktu', true );
     if ( ! empty( $stav_produktu ) ) {
       if ( $stav_produktu == 'used' ) {
         $stav_produktu_hodnota = 'Použité (bazar)';
@@ -1426,7 +1426,7 @@ function ceske_sluzby_xml_kategorie_sloupec( $columns, $column, $id ) {
       }
       $columns .= '<br />' . $stav_produktu_hodnota;
     }
-    $erotika = get_woocommerce_term_meta( $id, 'ceske-sluzby-xml-erotika', true );
+    $erotika = get_term_meta( $id, 'ceske-sluzby-xml-erotika', true );
     if ( $erotika ) {
       if ( $erotika == 'yes' ) {
         $erotika_hodnota = 'Erotický obsah';

--- a/includes/ceske-sluzby-functions.php
+++ b/includes/ceske-sluzby-functions.php
@@ -439,7 +439,7 @@ function ceske_sluzby_zobrazit_xml_hodnotu( $postmeta_id, $product_id, $post, $t
   $product_categories = wp_get_post_terms( $post->ID, 'product_cat' );
   if ( ! empty( $product_categories ) ) {
     foreach ( $product_categories as $kategorie_produktu ) {
-      $kategorie = get_woocommerce_term_meta( $kategorie_produktu->term_id, $termmeta_id, true );
+      $kategorie = get_term_meta( $kategorie_produktu->term_id, $termmeta_id, true );
       if ( ! empty( $kategorie ) ) {
         if ( $kategorie == $aktualni_kategorie_nazev_produkt ) {
           $kategorie_url = '<a href="' . admin_url(). 'edit-tags.php?action=edit&taxonomy=product_cat&tag_ID=' . $kategorie_produktu->term_id . '">' . $kategorie_produktu->name . '</a>';

--- a/includes/class-ceske-sluzby-product-tab.php
+++ b/includes/class-ceske-sluzby-product-tab.php
@@ -49,10 +49,10 @@ class WC_Product_Tab_Ceske_Sluzby_Admin {
     $extra_message_kategorie_array = array();
     $product_categories = wp_get_post_terms( $post->ID, 'product_cat' );
     foreach ( $product_categories as $kategorie_produktu ) {
-      $vynechano = get_woocommerce_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-vynechano', true );
-      $xml_feed_vynechano = get_woocommerce_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-feed-vynechano', true );
-      $stav_produktu = get_woocommerce_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-stav-produktu', true );
-      $kategorie_extra_message_ulozeno = get_woocommerce_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-zbozi-extra-message', true );
+      $vynechano = get_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-vynechano', true );
+      $xml_feed_vynechano = get_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-feed-vynechano', true );
+      $stav_produktu = get_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-stav-produktu', true );
+      $kategorie_extra_message_ulozeno = get_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-zbozi-extra-message', true );
       if ( ! empty( $vynechano ) ) {
         if ( ! empty( $vynechane_kategorie ) ) {
           $vynechane_kategorie .= ", ";
@@ -157,7 +157,7 @@ class WC_Product_Tab_Ceske_Sluzby_Admin {
       );
       $kategorie_heureka = "";
       foreach ( $product_categories as $kategorie_produktu ) {
-        $kategorie = get_woocommerce_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-heureka-kategorie', true );
+        $kategorie = get_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-heureka-kategorie', true );
         if ( ! empty( $kategorie ) ) {
           if ( empty( $kategorie_heureka ) ) {
             $kategorie_heureka = '<a href="' . admin_url(). 'edit-tags.php?action=edit&taxonomy=product_cat&tag_ID=' . $kategorie_produktu->term_id . '">' . $kategorie_produktu->name . '</a>';
@@ -208,7 +208,7 @@ class WC_Product_Tab_Ceske_Sluzby_Admin {
       }
       $kategorie_zbozi = "";
       foreach ( $product_categories as $kategorie_produktu ) {
-        $kategorie = get_woocommerce_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-zbozi-kategorie', true );
+        $kategorie = get_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-zbozi-kategorie', true );
         if ( ! empty( $kategorie ) ) {
           if ( empty( $kategorie_zbozi ) ) {
             $kategorie_zbozi = '<a href="' . admin_url(). 'edit-tags.php?action=edit&taxonomy=product_cat&tag_ID=' . $kategorie_produktu->term_id . '">' . $kategorie_produktu->name . '</a>';
@@ -270,7 +270,7 @@ class WC_Product_Tab_Ceske_Sluzby_Admin {
       echo '<div class="nadpis" style="margin-left: 12px; margin-top: 10px;"><strong>Glami</strong> (<a href="https://www.' . GLAMI_URL . '/info/feed/" target="_blank">obecný manuál</a>, <a target="_blank" href="' . site_url() . '/?feed=glami&pid=' . $post->ID . '">XML produktu</a>)</div>';
       $kategorie_glami = "";
       foreach ( $product_categories as $kategorie_produktu ) {
-        $kategorie = get_woocommerce_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-glami-kategorie', true );
+        $kategorie = get_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-glami-kategorie', true );
         if ( ! empty( $kategorie ) ) {
           if ( empty( $kategorie_glami ) ) {
             $kategorie_glami = '<a href="' . admin_url(). 'edit-tags.php?action=edit&taxonomy=product_cat&tag_ID=' . $kategorie_produktu->term_id . '">' . $kategorie_produktu->name . '</a>';

--- a/includes/class-ceske-sluzby-xml.php
+++ b/includes/class-ceske-sluzby-xml.php
@@ -67,11 +67,11 @@ function ceske_sluzby_xml_ziskat_vynechane_kategorie( $feed ) {
   $product_categories = get_terms( 'product_cat' ); // Do budoucna použít parametr meta_query?
   if ( ! empty( $product_categories ) && ! is_wp_error( $product_categories ) ) {
     foreach ( $product_categories as $kategorie_produktu ) {
-      $vynechano_vse = get_woocommerce_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-vynechano' );
+      $vynechano_vse = get_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-vynechano' );
       if ( ! empty( $vynechano_vse ) ) {
         $vynechane_kategorie[] = $kategorie_produktu->term_id;
       } else {
-        $vynechano = get_woocommerce_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-feed-vynechano' );
+        $vynechano = get_term_meta( $kategorie_produktu->term_id, 'ceske-sluzby-xml-feed-vynechano' );
         if ( ! empty( $vynechano ) && isset( $vynechano[$feed] ) ) {
           $vynechane_kategorie[] = $kategorie_produktu->term_id;
         }
@@ -94,7 +94,7 @@ function ceske_sluzby_xml_ziskat_prirazene_hodnoty_kategorie( $product_categorie
   $prirazene_hodnoty = array();
   if ( ! empty( $product_categories ) ) {
     foreach ( $product_categories as $kategorie ) {
-      $hodnota = get_woocommerce_term_meta( $kategorie->term_id, $termmeta_key, true );
+      $hodnota = get_term_meta( $kategorie->term_id, $termmeta_key, true );
       if ( ! empty( $hodnota ) ) {
         if ( is_array( $hodnota ) ) {
           $prirazene_hodnoty = array_merge( $prirazene_hodnoty, $hodnota );
@@ -120,7 +120,7 @@ function ceske_sluzby_xml_ziskat_kategorie_produktu( $product_id, $postmeta_prod
     $dostupne_kategorie = ceske_sluzby_xml_ziskat_prirazene_kategorie( $product_id );
     if ( $dostupne_kategorie ) {
       if ( $termmeta_kategorie ) {
-        $doplnena_kategorie = get_woocommerce_term_meta( $dostupne_kategorie[0]->term_id, $termmeta_kategorie, true );
+        $doplnena_kategorie = get_term_meta( $dostupne_kategorie[0]->term_id, $termmeta_kategorie, true );
       }
       if ( $doplnena_kategorie ) {
         $strom_kategorie = $doplnena_kategorie;
@@ -662,7 +662,7 @@ function ceske_sluzby_xml_ziskat_hodnotu_dat( $product_id, $vlastnosti_produkt, 
           $terms = get_the_terms( $product_id, $taxonomy );
           if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
             foreach ( $terms as $term ) {
-              $termmeta_value = get_woocommerce_term_meta( $term->term_id, $termmeta );
+              $termmeta_value = get_term_meta( $term->term_id, $termmeta );
               if ( ! empty( $termmeta_value ) ) {
                 // Pokud bude u produktu přiřazeno více položek ze stejné taxonomie, tak bude použita pouze poslední získaná hodnota.
                 $value = $termmeta_value;


### PR DESCRIPTION
Funkce `get_woocommerce_term_meta()` je [deprecated](https://docs.woocommerce.com/wc-apidocs/function-get_woocommerce_term_meta.html) od WooCommerce 3.6. 
Nahrazena funkcí `get_term_meta()`