### PR TITLE
dpd ikona spatna url a https mixed - zmena

### DIFF
--- a/ceske-sluzby.php
+++ b/ceske-sluzby.php
@@ -563,7 +563,7 @@ function ceske_sluzby_dpd_parcelshop_zobrazit_pobocky() {
         $parametry = array( 'provider' => 5, 'country' => $zeme_code ); ?>
         <tr class="dpd-parcelshop">
           <td>
-            <img src="http://www.dpdparcelshop.cz/images/DPD-logo.png" width="140" border="0">
+            <img src="https://pickup.dpd.cz/images/DPD-logo.png" width="140" border="0">
           </td>
           <td>
             <font size="2">DPD ParcelShop - výběr pobočky:</font><br>


### PR DESCRIPTION
566 radek zamena <img src="http://www.dpdparcelshop.cz/images/DPD-logo.png" width="140" border="0"> na
https://pickup.dpd.cz/images/DPD-logo.png

u checkout to spusobuje https mixed (non http)

url http://www.dpdparcelshop.cz se dokonce redirectuje na https://pickup.dpd.cz/